### PR TITLE
Use correct MultiConfig class

### DIFF
--- a/autogpt/args.py
+++ b/autogpt/args.py
@@ -3,11 +3,11 @@ import argparse
 
 from colorama import Fore
 from autogpt import utils
-from autogpt.config import Config
 from autogpt.logs import logger
 from autogpt.memory import get_supported_memory_backends
+from multigpt.multi_config import MultiConfig
 
-CFG = Config()
+CFG = MultiConfig()
 
 
 def parse_arguments() -> None:


### PR DESCRIPTION
All morning I was working on creating this functionality, and then I found your fork! Thank you, and great job so far!

### Background
The command line args (e.g., `--gpt3only`) were not making it to the `MultiConfig()`, only the `Config()`. This would result in the following error:
```python
Debug Mode:  ENABLED
GPT3.5 Only Mode:  ENABLED
FAST MODEL: gpt-3.5-turbo 
SMART MODEL BEFORE: gpt-4 # note: value from .env
SMART MODEL AFTER: gpt-3.5-turbo  # note: parsed command line args
Welcome to MultiGPT!  I am the orchestrator of your AI assistants.
Define the task you want to accomplish and I will gather a group of expertGPTs to help you.  Be specific. Prefer 'Achieve world domination by creating a raccoon army!' to 'Achieve world domination!'
Task: Achieve world peace by creating a raccoon band!
Creating chat completion with model gpt-4, temperature 0.1, max_tokens 1000 # note: you can see it's trying to use the .env smart model
Traceback (most recent call last):
...
openai.error.InvalidRequestError: The model: `gpt-4` does not exist
```

### Changes
I switched out the config class from `autogpt.config.Config` to `multigpt.multi_config.MultiConfig`.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guide lines. -->
